### PR TITLE
mlir/Dialect/Affine: expose options to C++ API for affine parallelize

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Passes.h
+++ b/mlir/include/mlir/Dialect/Affine/Passes.h
@@ -45,8 +45,11 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createAffineLoopInvariantCodeMotionPass();
 
 /// Creates a pass to convert all parallel affine.for's into 1-d affine.parallel
-/// ops.
+/// ops. We also include a variant of the function that takes in the
+/// AffineParallelizeOptions.
 std::unique_ptr<OperationPass<func::FuncOp>> createAffineParallelizePass();
+std::unique_ptr<OperationPass<func::FuncOp>> createAffineParallelizePass(
+    const affine::AffineParallelizeOptions&);
 
 /// Apply normalization transformations to affine loop-like ops. If
 /// `promoteSingleIter` is true, single iteration loops are promoted (i.e., the

--- a/mlir/lib/Dialect/Affine/Transforms/AffineParallelize.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/AffineParallelize.cpp
@@ -42,6 +42,10 @@ namespace {
 /// Convert all parallel affine.for op into 1-D affine.parallel op.
 struct AffineParallelize
     : public affine::impl::AffineParallelizeBase<AffineParallelize> {
+   AffineParallelize()
+       : affine::impl::AffineParallelizeBase<AffineParallelize>() {}
+   AffineParallelize(const AffineParallelizeOptions& options)
+       : affine::impl::AffineParallelizeBase<AffineParallelize>(options) {}
   void runOnOperation() override;
 };
 
@@ -94,4 +98,10 @@ void AffineParallelize::runOnOperation() {
 std::unique_ptr<OperationPass<func::FuncOp>>
 mlir::affine::createAffineParallelizePass() {
   return std::make_unique<AffineParallelize>();
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+mlir::affine::createAffineParallelizePass(
+    const affine::AffineParallelizeOptions& options) {
+  return std::make_unique<AffineParallelize>(options);
 }


### PR DESCRIPTION
This commit exposes a constructor for the AffineParallelize pass that exposes the AffineParallelizeOptions so that C++ applications can run passes that change from the default options.